### PR TITLE
Hack for JP iTunes and Unicode Metadata Support

### DIFF
--- a/DiscordRPC.cs
+++ b/DiscordRPC.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.InteropServices;
+using System;
 
 // This file is a modified version of RPC.cs from https://github.com/cthpw103/discord-rpc-sharp
 
@@ -31,10 +32,11 @@ namespace iTunesRichPresence {
             public RequestCallback requestCallback;
         }
 
-        [System.Serializable]
-        public struct RichPresence {
-            public string state; /* max 128 bytes */
-            public string details; /* max 128 bytes */
+        [System.Serializable, StructLayout(LayoutKind.Sequential)]
+        public struct RichPresence
+        {
+            public IntPtr state; /* max 128 bytes */
+            public IntPtr details; /* max 128 bytes */
             public long startTimestamp;
             public long endTimestamp;
             public string largeImageKey; /* max 32 bytes */

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Runtime.InteropServices;
+using System.Text;
 using System.Windows.Forms;
 using iTunesLib;
 
@@ -38,8 +40,19 @@ namespace iTunesRichPresence {
             _iTunes = new iTunesApp();
         }
         
+        string toUTF8(string toconv)
+        {
+            return Encoding.UTF8.GetString(Encoding.UTF8.GetBytes(toconv.Trim()));
+        }
+
         private void UpdatePresence() {
-            var presence = new DiscordRPC.RichPresence {details = $"{_currentArtist} - {_currentTitle}"};
+            var presence = new DiscordRPC.RichPresence {};
+
+            string details = toUTF8($"{_currentArtist} - {_currentTitle}");
+            IntPtr details_ptr = Marshal.AllocCoTaskMem(Encoding.UTF8.GetByteCount(details));
+            Marshal.Copy(Encoding.UTF8.GetBytes(details), 0, details_ptr, Encoding.UTF8.GetByteCount(details));
+            presence.details = details_ptr;
+
             if (_currentTitle == "DVNO") {
                 presence.largeImageKey = "dvno";
                 presence.smallImageKey = "itunes_logo";
@@ -48,18 +61,28 @@ namespace iTunesRichPresence {
             else {
                 presence.largeImageKey = "itunes_logo_big";
             }
+            string state = "";
 
             if (_iTunes.CurrentPlaylist.Kind == ITPlaylistKind.ITPlaylistKindUser) {
-                presence.state = _iTunes.CurrentPlaylist.Name == "Music"
-                    ? $"Album: {_iTunes.CurrentTrack.Album}"
-                    : $"Playlist: {_iTunes.CurrentPlaylist.Name}";
+                state = _iTunes.CurrentPlaylist.Name == "Music" || _iTunes.CurrentPlaylist.Name == "ミュージック"
+                    ? toUTF8($"Album: {_iTunes.CurrentTrack.Album}")
+                    : toUTF8($"Playlist: {_iTunes.CurrentPlaylist.Name}");
+                IntPtr state_ptr = Marshal.AllocCoTaskMem(Encoding.UTF8.GetByteCount(state));
+                Marshal.Copy(Encoding.UTF8.GetBytes(state), 0, state_ptr, Encoding.UTF8.GetByteCount(state));
+                presence.state = state_ptr;
             }
             else {
-                presence.state = $"Album: {_iTunes.CurrentTrack.Album}";
+                state = toUTF8($"Album: {_iTunes.CurrentTrack.Album}");
+                IntPtr state_ptr = Marshal.AllocCoTaskMem(Encoding.UTF8.GetByteCount(state));
+                Marshal.Copy(Encoding.UTF8.GetBytes(state), 0, state_ptr, Encoding.UTF8.GetByteCount(state));
+                presence.state = state_ptr;
             }
 
             if (_currentState != ITPlayerState.ITPlayerStatePlaying) {
-                presence.state = "Paused";
+                state = toUTF8("Paused");
+                IntPtr state_ptr = Marshal.AllocCoTaskMem(Encoding.UTF8.GetByteCount(state));
+                Marshal.Copy(Encoding.UTF8.GetBytes(state), 0, state_ptr, Encoding.UTF8.GetByteCount(state));
+                presence.state = state_ptr;
             }
 
             presence.startTimestamp = DateTimeOffset.Now.ToUnixTimeSeconds() - _iTunes.PlayerPosition;


### PR DESCRIPTION
Ideally, we'd use `RichPresenceNative` wrappers instead of the `RichPresence` ones and the same logic I used here, but this works (feel free to make the needed changes to use `IntPtr` instead of `string` into `RichPresenceNative` and not accepting this PR). I also added logic for the Japanese `Music` playlist (`ミュージック`), but other playlist names could be necessary.