### PR TITLE
Revert "Hack for JP iTunes and Unicode Metadata Support"

### DIFF
--- a/DiscordRPC.cs
+++ b/DiscordRPC.cs
@@ -1,5 +1,4 @@
 ﻿using System.Runtime.InteropServices;
-using System;
 
 // This file is a modified version of RPC.cs from https://github.com/cthpw103/discord-rpc-sharp
 
@@ -32,11 +31,10 @@ namespace iTunesRichPresence {
             public RequestCallback requestCallback;
         }
 
-        [System.Serializable, StructLayout(LayoutKind.Sequential)]
-        public struct RichPresence
-        {
-            public IntPtr state; /* max 128 bytes */
-            public IntPtr details; /* max 128 bytes */
+        [System.Serializable]
+        public struct RichPresence {
+            public string state; /* max 128 bytes */
+            public string details; /* max 128 bytes */
             public long startTimestamp;
             public long endTimestamp;
             public string largeImageKey; /* max 32 bytes */

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Runtime.InteropServices;
-using System.Text;
 using System.Windows.Forms;
 using iTunesLib;
 
@@ -47,19 +45,8 @@ namespace iTunesRichPresence {
             _iTunes = new iTunesApp();
         }
         
-        string toUTF8(string toconv)
-        {
-            return Encoding.UTF8.GetString(Encoding.UTF8.GetBytes(toconv.Trim()));
-        }
-
         private void UpdatePresence() {
-            var presence = new DiscordRPC.RichPresence {};
-
-            string details = toUTF8($"{_currentArtist} - {_currentTitle}");
-            IntPtr details_ptr = Marshal.AllocCoTaskMem(Encoding.UTF8.GetByteCount(details));
-            Marshal.Copy(Encoding.UTF8.GetBytes(details), 0, details_ptr, Encoding.UTF8.GetByteCount(details));
-            presence.details = details_ptr;
-
+            var presence = new DiscordRPC.RichPresence {details = $"{_currentArtist} - {_currentTitle}"};
             if (_currentTitle == "DVNO") {
                 presence.largeImageKey = "dvno";
                 presence.smallImageKey = "itunes_logo";
@@ -68,28 +55,18 @@ namespace iTunesRichPresence {
             else {
                 presence.largeImageKey = "itunes_logo_big";
             }
-            string state = "";
 
             if (_iTunes.CurrentPlaylist.Kind == ITPlaylistKind.ITPlaylistKindUser) {
-                state = _iTunes.CurrentPlaylist.Name == "Music" || _iTunes.CurrentPlaylist.Name == "ミュージック"
-                    ? toUTF8($"Album: {_iTunes.CurrentTrack.Album}")
-                    : toUTF8($"Playlist: {_iTunes.CurrentPlaylist.Name}");
-                IntPtr state_ptr = Marshal.AllocCoTaskMem(Encoding.UTF8.GetByteCount(state));
-                Marshal.Copy(Encoding.UTF8.GetBytes(state), 0, state_ptr, Encoding.UTF8.GetByteCount(state));
-                presence.state = state_ptr;
+                presence.state = _iTunes.CurrentPlaylist.Name == "Music"
+                    ? $"Album: {_iTunes.CurrentTrack.Album}"
+                    : $"Playlist: {_iTunes.CurrentPlaylist.Name}";
             }
             else {
-                state = toUTF8($"Album: {_iTunes.CurrentTrack.Album}");
-                IntPtr state_ptr = Marshal.AllocCoTaskMem(Encoding.UTF8.GetByteCount(state));
-                Marshal.Copy(Encoding.UTF8.GetBytes(state), 0, state_ptr, Encoding.UTF8.GetByteCount(state));
-                presence.state = state_ptr;
+                presence.state = $"Album: {_iTunes.CurrentTrack.Album}";
             }
 
             if (_currentState != ITPlayerState.ITPlayerStatePlaying) {
-                state = toUTF8("Paused");
-                IntPtr state_ptr = Marshal.AllocCoTaskMem(Encoding.UTF8.GetByteCount(state));
-                Marshal.Copy(Encoding.UTF8.GetBytes(state), 0, state_ptr, Encoding.UTF8.GetByteCount(state));
-                presence.state = state_ptr;
+                presence.state = "Paused";
             }
 
             presence.startTimestamp = DateTimeOffset.Now.ToUnixTimeSeconds() - _iTunes.PlayerPosition;


### PR DESCRIPTION
Reverts nint8835/iTunesRichPresence#3. Hack appeared to initially work, but can cause garbled text. For example, [https://i.bootleg.technology/Tzu9IGyHeh.png](https://i.bootleg.technology/Tzu9IGyHeh.png)